### PR TITLE
add datalad-osf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN bash /src/install_scripts/24.install_bids-validator_sudo.sh > log_24_bids-va
 RUN bash /src/install_scripts/25.install_niftyreg_by_source.sh /opt > log_25_niftyreg
 RUN bash /src/install_scripts/28.install_gradunwarp_by_source.sh /opt > log_28_gradunwarp
 RUN bash /src/install_scripts/29.install_connectomeworkbench_by_binary.sh /opt > log_29_workbench
+RUN bash /src/install_scripts/30.install_datalad-osf_by_source_sudo.sh /opt > log_30_dataladosf
 
 
 #remove all install scripts

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Singularity image for neuroimaging dependencies. Base image for khanlab apps and
 * NiftyReg
 * gradunwarp
 * dcmstack
+* Connectome Workbench
+* Datalad-osf
 
 Commits and pull-requests to this repository rebuild the `latest` version on Docker Hub, which is updated nightly to Singularity Hub. Releases on Docker Hub and Singularity Hub are built whenever a tag named `v.*` is committed. To avoid re-building on minor commits (e.g. changes to documentation), use `[skip ci]` in the commit message.
 

--- a/install_scripts/30.install_datalad-osf_by_source_sudo.sh
+++ b/install_scripts/30.install_datalad-osf_by_source_sudo.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# pip3
+curl https://bootstrap.pypa.io/get-pip.py | python3 
+
+# datalad-osf
+if [ -e /tmp/datalad-osf ]
+then
+    rm -rf /tmp/datalad-osf
+fi 
+
+git clone https://github.com/khanlab/datalad-osf /tmp/datalad-osf && cd /tmp/datalad-osf
+pip3 install -r requirements.txt && python3 setup.py install && cd 

--- a/install_scripts/30.install_datalad-osf_by_source_sudo.sh
+++ b/install_scripts/30.install_datalad-osf_by_source_sudo.sh
@@ -10,4 +10,4 @@ then
 fi 
 
 git clone https://github.com/khanlab/datalad-osf /tmp/datalad-osf && cd /tmp/datalad-osf
-pip3 install -r requirements.txt && python3 setup.py install && cd 
+sudo pip3 install -r requirements.txt && sudo python3 setup.py install && cd 


### PR DESCRIPTION
- added python based cli for datalad-osf
  - documentation can be found at [khanlab/datalad-osf](https://github.com/khanlab/datalad-osf) repository under docs
- circleci was able to succesfully build on forced rerun
  - cancelled a couple of checks to avoid rerunning
- tested locally for cli command